### PR TITLE
Send json in the body of POST requests

### DIFF
--- a/lib/aria_sdk/aria_rest_client.rb
+++ b/lib/aria_sdk/aria_rest_client.rb
@@ -23,7 +23,8 @@ class AriaRestClient
 
         options.merge!(defaults)
 
-        result = self.class.post(self.url, :body => options)
+        headers = { 'Content-Type' => 'application/json' }
+        result = self.class.post(self.url, :body => options.to_json, :headers => headers)
 
         return result
     end


### PR DESCRIPTION
httparty does not properly serialize nested hashes, specifically when "application/x-www-form-urlencoded" is used.

Switching the Content-Type to "application/json" solves this problem.
